### PR TITLE
fix: Missing method when policy oauth2 fail

### DIFF
--- a/src/main/java/io/gravitee/resource/oauth2/am/OAuth2AMResource.java
+++ b/src/main/java/io/gravitee/resource/oauth2/am/OAuth2AMResource.java
@@ -163,7 +163,7 @@ public class OAuth2AMResource extends OAuth2Resource<OAuth2ResourceConfiguration
                     // retrieve active indicator
                     JsonObject jsonObject = buffer.toJsonObject();
                     boolean active = jsonObject.getBoolean(INTROSPECTION_ACTIVE_INDICATOR, false);
-                    responseHandler.handle(new OAuth2Response(active, (active) ? buffer.toString() : "{\"error\": \"Invalid Access Token\"}"));
+                    responseHandler.handle(new OAuth2Response(active, (active) ? buffer.toString() : "Invalid Access Token"));
                 } else {
                     responseHandler.handle(new OAuth2Response(true, buffer.toString()));
                 }


### PR DESCRIPTION
This closes gravitee-io/issues#2149