### PR TITLE
fix: include the scopes when returning the protected resource metadata from the oauth2 policy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <gravitee-common.version>4.9.0</gravitee-common.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-gateway-api.version>3.13.0</gravitee-gateway-api.version>
-        <gravitee-resource-oauth2-provider-api.version>1.5.0</gravitee-resource-oauth2-provider-api.version>
+        <gravitee-resource-oauth2-provider-api.version>1.5.1</gravitee-resource-oauth2-provider-api.version>
         <gravitee-node.version>7.26.1</gravitee-node.version>
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
@@ -89,8 +89,10 @@
         <dependency>
             <groupId>io.gravitee.resource</groupId>
             <artifactId>gravitee-resource-oauth2-provider-api</artifactId>
+            <!-- Version specified to avoid a breaking change. Once the versions of APIM under 4.12 will not be maintained anymore
+                    we can move back to scope provided and remove the version. -->
+            <!-- <scope>provided</scope> -->
             <version>${gravitee-resource-oauth2-provider-api.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/gravitee/resource/oauth2/am/OAuth2AMResource.java
+++ b/src/main/java/io/gravitee/resource/oauth2/am/OAuth2AMResource.java
@@ -352,9 +352,13 @@ public class OAuth2AMResource extends OAuth2Resource<OAuth2ResourceConfiguration
     }
 
     @Override
-    public OAuth2ResourceMetadata getProtectedResourceMetadata(String protectedResourceUri) {
+    public OAuth2ResourceMetadata getProtectedResourceMetadata(String protectedResourceUri, List<String> scopesSupported) {
         URI authServerUri = URI.create(configuration().getServerURL() + "/" + configuration().getSecurityDomain() + "/oidc");
         String authorizationServer = authServerUri.normalize().toString().replaceAll("/+$", "");
-        return new OAuth2ResourceMetadata(protectedResourceUri, List.of(authorizationServer), List.of());
+        return new OAuth2ResourceMetadata(
+            protectedResourceUri,
+            List.of(authorizationServer),
+            scopesSupported != null ? scopesSupported : List.of()
+        );
     }
 }

--- a/src/test/java/io/gravitee/resource/oauth2/am/OAuth2AMResourceTest.java
+++ b/src/test/java/io/gravitee/resource/oauth2/am/OAuth2AMResourceTest.java
@@ -38,6 +38,7 @@ import io.gravitee.resource.oauth2.am.configuration.OAuth2ResourceConfiguration;
 import io.gravitee.resource.oauth2.api.OAuth2ResourceMetadata;
 import io.vertx.rxjava3.core.Vertx;
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeAll;
@@ -46,7 +47,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationContext;
 
@@ -331,6 +331,20 @@ public class OAuth2AMResourceTest {
         testGetProtectedResourceMetadata("https://am.gateway.dev", "/test/");
     }
 
+    @Test
+    public void getProtectedResourceMetadata_withScopesSupported() {
+        configuration.setServerURL("https://am.gateway.dev");
+        configuration.setSecurityDomain("test");
+        OAuth2ResourceMetadata resourceMetadata = resource.getProtectedResourceMetadata(
+            "https://backend.com",
+            List.of("openid", "profile", "email")
+        );
+        assertThat(resourceMetadata.protectedResourceUri()).isEqualTo("https://backend.com");
+        assertThat(resourceMetadata.authorizationServers().get(0)).isEqualTo("https://am.gateway.dev/test/oidc");
+        assertThat(resourceMetadata.authorizationServers()).hasSize(1);
+        assertThat(resourceMetadata.scopesSupported()).containsExactly("openid", "profile", "email");
+    }
+
     private void testGetProtectedResourceMetadata(String serverUrl, String securityDomain)
         throws NoSuchFieldException, IllegalAccessException {
         OAuth2AMResource resource = new OAuth2AMResource();
@@ -340,7 +354,7 @@ public class OAuth2AMResourceTest {
         Field configurationField = AbstractConfigurableResource.class.getDeclaredField("configuration");
         configurationField.setAccessible(true);
         configurationField.set(resource, configuration);
-        OAuth2ResourceMetadata resourceMetadata = resource.getProtectedResourceMetadata("https://backend.com");
+        OAuth2ResourceMetadata resourceMetadata = resource.getProtectedResourceMetadata("https://backend.com", List.of());
         assertThat(resourceMetadata.protectedResourceUri()).isEqualTo("https://backend.com");
         assertThat(resourceMetadata.authorizationServers().get(0)).isEqualTo("https://am.gateway.dev/test/oidc");
         assertThat(resourceMetadata.authorizationServers()).hasSize(1);


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-13671
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.1-apim-13671-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-oauth2-provider-am/4.0.1-apim-13671-SNAPSHOT/gravitee-resource-oauth2-provider-am-4.0.1-apim-13671-SNAPSHOT.zip)
  <!-- Version placeholder end -->
