### PR TITLE
refactor: harden Vert.x request handling in introspect/userInfo

### DIFF
--- a/src/main/java/io/gravitee/resource/oauth2/am/OAuth2AMResource.java
+++ b/src/main/java/io/gravitee/resource/oauth2/am/OAuth2AMResource.java
@@ -40,6 +40,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.rxjava3.core.Vertx;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import javax.inject.Inject;
@@ -129,7 +130,9 @@ public class OAuth2AMResource extends OAuth2Resource<OAuth2ResourceConfiguration
         introspectionEndpointAuthorization =
             AUTHORIZATION_HEADER_BASIC_SCHEME +
             Base64.getEncoder().encodeToString(
-                (configuration().getClientId() + AUTHORIZATION_HEADER_VALUE_BASE64_SEPARATOR + configuration().getClientSecret()).getBytes()
+                (configuration().getClientId() + AUTHORIZATION_HEADER_VALUE_BASE64_SEPARATOR + configuration().getClientSecret()).getBytes(
+                    StandardCharsets.UTF_8
+                )
             );
 
         String path = (!introspectionUrl.getPath().isEmpty()) ? introspectionUrl.getPath() : PATH_SEPARATOR;
@@ -177,63 +180,51 @@ public class OAuth2AMResource extends OAuth2Resource<OAuth2ResourceConfiguration
 
         httpClient
             .request(reqOptions)
+            .compose(request -> request.send("token=" + accessToken))
             .onFailure(event -> {
                 logger.debug("An error occurs while checking access token", event);
                 responseHandler.handle(new OAuth2Response(event));
             })
-            .onSuccess(request -> {
-                request.exceptionHandler(event -> {
-                    logger.debug("An error occurs while checking access token", event);
-                    responseHandler.handle(new OAuth2Response(event));
-                });
-                request
-                    .response()
-                    .onComplete(asyncResponse -> {
-                        if (asyncResponse.failed()) {
-                            logger.debug("An error occurs while checking access token", asyncResponse.cause());
-                            responseHandler.handle(new OAuth2Response(asyncResponse.cause()));
+            .onSuccess(response -> {
+                logger.debug("AM Introspection endpoint returns a response with a {} status code", response.statusCode());
+                response
+                    .body()
+                    .onComplete(bodyResult -> {
+                        if (bodyResult.failed()) {
+                            logger.debug("An error occurs while reading introspection response body", bodyResult.cause());
+                            responseHandler.handle(new OAuth2Response(bodyResult.cause()));
+                            return;
+                        }
+                        var buffer = bodyResult.result();
+                        if (response.statusCode() == HttpStatusCode.OK_200) {
+                            if (configuration().getVersion() == OAuth2ResourceConfiguration.Version.V1_X) {
+                                responseHandler.handle(new OAuth2Response(true, buffer.toString()));
+                            } else {
+                                // Introspection Response from AM v2 always returns HTTP 200
+                                // with an "active" boolean indicator of whether or not the presented token is currently active.
+                                // retrieve active indicator
+                                try {
+                                    JsonObject jsonObject = buffer.toJsonObject();
+                                    boolean active = jsonObject.getBoolean(INTROSPECTION_ACTIVE_INDICATOR, false);
+                                    responseHandler.handle(
+                                        new OAuth2Response(active, (active) ? buffer.toString() : "{\"error\": \"Invalid Access Token\"}")
+                                    );
+                                } catch (Exception e) {
+                                    logger.debug("An error occurs while parsing introspection response", e);
+                                    responseHandler.handle(new OAuth2Response(e));
+                                }
+                            }
                         } else {
-                            final HttpClientResponse response = asyncResponse.result();
-                            logger.debug("AM Introspection endpoint returns a response with a {} status code", response.statusCode());
-                            response
-                                .body()
-                                .onComplete(bodyResult -> {
-                                    if (bodyResult.failed()) {
-                                        logger.debug("An error occurs while reading introspection response body", bodyResult.cause());
-                                        responseHandler.handle(new OAuth2Response(bodyResult.cause()));
-                                        return;
-                                    }
-                                    var buffer = bodyResult.result();
-                                    if (response.statusCode() == HttpStatusCode.OK_200) {
-                                        if (configuration().getVersion() == OAuth2ResourceConfiguration.Version.V1_X) {
-                                            responseHandler.handle(new OAuth2Response(true, buffer.toString()));
-                                        } else {
-                                            // Introspection Response from AM v2 always returns HTTP 200
-                                            // with an "active" boolean indicator of whether or not the presented token is currently active.
-                                            // retrieve active indicator
-                                            JsonObject jsonObject = buffer.toJsonObject();
-                                            boolean active = jsonObject.getBoolean(INTROSPECTION_ACTIVE_INDICATOR, false);
-                                            responseHandler.handle(
-                                                new OAuth2Response(
-                                                    active,
-                                                    (active) ? buffer.toString() : "{\"error\": \"Invalid Access Token\"}"
-                                                )
-                                            );
-                                        }
-                                    } else {
-                                        logger.debug(
-                                            "An error occurs while checking access token. Request ends with status {}: {}",
-                                            response.statusCode(),
-                                            buffer.toString()
-                                        );
-                                        responseHandler.handle(
-                                            new OAuth2Response(new OAuth2ResourceException("An error occurs while checking access token"))
-                                        );
-                                    }
-                                });
+                            logger.debug(
+                                "An error occurs while checking access token. Request ends with status {}: {}",
+                                response.statusCode(),
+                                buffer.toString()
+                            );
+                            responseHandler.handle(
+                                new OAuth2Response(new OAuth2ResourceException("An error occurs while checking access token"))
+                            );
                         }
                     });
-                request.end("token=" + accessToken);
             });
     }
 
@@ -251,52 +242,38 @@ public class OAuth2AMResource extends OAuth2Resource<OAuth2ResourceConfiguration
 
         httpClient
             .request(reqOptions)
+            .compose(HttpClientRequest::send)
             .onFailure(event -> {
                 logger.debug("An error occurs while getting userinfo from access token", event);
                 responseHandler.handle(new UserInfoResponse(event));
             })
-            .onSuccess(request -> {
-                request.exceptionHandler(event -> {
-                    logger.debug("An error occurs while getting userinfo from access token", event);
-                    responseHandler.handle(new UserInfoResponse(event));
-                });
-                request
-                    .response()
-                    .onComplete(asyncResponse -> {
-                        if (asyncResponse.failed()) {
-                            logger.debug("An error occurs while getting userinfo from access token", asyncResponse.cause());
-                            responseHandler.handle(new UserInfoResponse(asyncResponse.cause()));
-                        } else {
-                            final HttpClientResponse response = asyncResponse.result();
-                            response
-                                .body()
-                                .onComplete(bodyResult -> {
-                                    if (bodyResult.failed()) {
-                                        logger.debug("An error occurs while reading userinfo response body", bodyResult.cause());
-                                        responseHandler.handle(new UserInfoResponse(bodyResult.cause()));
-                                        return;
-                                    }
-                                    var buffer = bodyResult.result();
-                                    logger.debug("Userinfo endpoint returns a response with a {} status code", response.statusCode());
+            .onSuccess(response -> {
+                response
+                    .body()
+                    .onComplete(bodyResult -> {
+                        if (bodyResult.failed()) {
+                            logger.debug("An error occurs while reading userinfo response body", bodyResult.cause());
+                            responseHandler.handle(new UserInfoResponse(bodyResult.cause()));
+                            return;
+                        }
+                        var buffer = bodyResult.result();
+                        logger.debug("Userinfo endpoint returns a response with a {} status code", response.statusCode());
 
-                                    if (response.statusCode() == HttpStatusCode.OK_200) {
-                                        responseHandler.handle(new UserInfoResponse(true, buffer.toString()));
-                                    } else {
-                                        logger.debug(
-                                            "An error occurs while getting userinfo from access token. Request ends with status {}: {}",
-                                            response.statusCode(),
-                                            buffer.toString()
-                                        );
-                                        responseHandler.handle(
-                                            new UserInfoResponse(
-                                                new OAuth2ResourceException("An error occurs while getting userinfo from access token")
-                                            )
-                                        );
-                                    }
-                                });
+                        if (response.statusCode() == HttpStatusCode.OK_200) {
+                            responseHandler.handle(new UserInfoResponse(true, buffer.toString()));
+                        } else {
+                            logger.debug(
+                                "An error occurs while getting userinfo from access token. Request ends with status {}: {}",
+                                response.statusCode(),
+                                buffer.toString()
+                            );
+                            responseHandler.handle(
+                                new UserInfoResponse(
+                                    new OAuth2ResourceException("An error occurs while getting userinfo from access token")
+                                )
+                            );
                         }
                     });
-                request.end();
             });
     }
 
@@ -314,6 +291,10 @@ public class OAuth2AMResource extends OAuth2Resource<OAuth2ResourceConfiguration
     public OAuth2ResourceMetadata getProtectedResourceMetadata(String protectedResourceUri, List<String> scopesSupported) {
         URI authServerUri = URI.create(configuration().getServerURL() + "/" + configuration().getSecurityDomain() + "/oidc");
         String authorizationServer = authServerUri.normalize().toString().replaceAll("/+$", "");
-        return new OAuth2ResourceMetadata(protectedResourceUri, List.of(authorizationServer), scopesSupported);
+        return new OAuth2ResourceMetadata(
+            protectedResourceUri,
+            List.of(authorizationServer),
+            scopesSupported != null ? scopesSupported : List.of()
+        );
     }
 }

--- a/src/test/java/io/gravitee/resource/oauth2/am/OAuth2AMResourceTest.java
+++ b/src/test/java/io/gravitee/resource/oauth2/am/OAuth2AMResourceTest.java
@@ -25,6 +25,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.lenient;
 
+import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.MediaType;
@@ -41,6 +42,7 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -183,6 +185,52 @@ public class OAuth2AMResourceTest {
     }
 
     @Test
+    public void shouldHandleMalformedIntrospectionBody_v2_withoutHanging() throws Exception {
+        String accessToken = "xxxx-xxxx-xxxx-xxxx";
+        // AM v2 introspection always returns HTTP 200, but a malformed/empty body must not hang the request
+        wiremock.stubFor(post(urlEqualTo("/domain/oauth/introspect")).willReturn(aResponse().withStatus(200).withBody("not-a-json")));
+
+        final CountDownLatch lock = new CountDownLatch(1);
+
+        configuration.setVersion(OAuth2ResourceConfiguration.Version.V2_X);
+
+        resource.doStart();
+
+        resource.introspect(accessToken, oAuth2Response -> {
+            assertThat(oAuth2Response.isSuccess()).isFalse();
+            lock.countDown();
+        });
+
+        assertThat(lock.await(10000, TimeUnit.MILLISECONDS)).isTrue();
+    }
+
+    @Test
+    public void shouldInvokeHandlerExactlyOnce_whenConnectionResetMidExchange() throws Exception {
+        String accessToken = "xxxx-xxxx-xxxx-xxxx";
+        // Transport-level failure: the connection is reset while the exchange is in flight.
+        // The handler must be invoked exactly once (a single failure response), never twice.
+        wiremock.stubFor(post(urlEqualTo("/domain/oauth/introspect")).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+        final AtomicInteger invocations = new AtomicInteger(0);
+        final CountDownLatch firstInvocation = new CountDownLatch(1);
+
+        configuration.setVersion(OAuth2ResourceConfiguration.Version.V2_X);
+
+        resource.doStart();
+
+        resource.introspect(accessToken, oAuth2Response -> {
+            invocations.incrementAndGet();
+            assertThat(oAuth2Response.isSuccess()).isFalse();
+            firstInvocation.countDown();
+        });
+
+        // Wait for the (single) failure callback, then leave a grace period for any erroneous second call.
+        assertThat(firstInvocation.await(10000, TimeUnit.MILLISECONDS)).isTrue();
+        Thread.sleep(500);
+        assertThat(invocations.get()).isEqualTo(1);
+    }
+
+    @Test
     public void shouldNotValidateAccessToken_v2_not_200() throws Exception {
         String accessToken = "xxxx-xxxx-xxxx-xxxx";
         wiremock.stubFor(post(urlEqualTo("/domain/oauth/introspect")).willReturn(aResponse().withStatus(401)));
@@ -320,6 +368,17 @@ public class OAuth2AMResourceTest {
         assertThat(resourceMetadata.authorizationServers().get(0)).isEqualTo("https://am.gateway.dev/test/oidc");
         assertThat(resourceMetadata.authorizationServers()).hasSize(1);
         assertThat(resourceMetadata.scopesSupported()).containsExactly("openid", "profile", "email");
+    }
+
+    @Test
+    public void getProtectedResourceMetadata_withNullScopesSupported_returnsEmptyList() {
+        configuration.setServerURL("https://am.gateway.dev");
+        configuration.setSecurityDomain("test");
+        OAuth2ResourceMetadata resourceMetadata = resource.getProtectedResourceMetadata("https://backend.com", null);
+        assertThat(resourceMetadata.protectedResourceUri()).isEqualTo("https://backend.com");
+        assertThat(resourceMetadata.authorizationServers().get(0)).isEqualTo("https://am.gateway.dev/test/oidc");
+        assertThat(resourceMetadata.authorizationServers()).hasSize(1);
+        assertThat(resourceMetadata.scopesSupported()).isEmpty();
     }
 
     private void testGetProtectedResourceMetadata(String serverUrl, String securityDomain)


### PR DESCRIPTION
Addresses the Gemini review comments on #93.

- **`introspect` / `userInfo`**: switch to `compose`/`send` so the response handler fires exactly once. The previous nested-callback form could double-invoke it on a transport-level failure (request `exceptionHandler` + failed `response()` future).
- **v2 introspection**: wrap JSON parsing in try-catch — a malformed/empty body now returns a failure response instead of hanging until the 30s timeout.
- **Client credentials**: pin `StandardCharsets.UTF_8` when Base64-encoding.
- **`getProtectedResourceMetadata`**: null-guard `scopesSupported`.

Tests: +3 (`malformed body`, `null scopes`, `connection reset → handler invoked once`). 18 pass.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.0-fix-oauth2-vertx-request-handling-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-oauth2-provider-am/5.0.0-fix-oauth2-vertx-request-handling-SNAPSHOT/gravitee-resource-oauth2-provider-am-5.0.0-fix-oauth2-vertx-request-handling-SNAPSHOT.zip)
  <!-- Version placeholder end -->
